### PR TITLE
feat: Limit parallel/concurrency

### DIFF
--- a/parser/src/asyncreq.rs
+++ b/parser/src/asyncreq.rs
@@ -1,0 +1,13 @@
+use anyhow::Result;
+
+use reqwest::{RequestBuilder, Response};
+use tokio::sync::Semaphore;
+
+static PERMITS: Semaphore = Semaphore::const_new(20);
+
+/// Make a request in async.
+/// This will acquire a permit and release it after the request is done.
+pub async fn make_req(req: RequestBuilder) -> Result<Response, reqwest::Error> {
+    let _permit = PERMITS.acquire().await.unwrap();
+    req.send().await
+}

--- a/parser/src/main.rs
+++ b/parser/src/main.rs
@@ -15,6 +15,7 @@ use std::io::{BufRead, BufReader};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+mod asyncreq;
 mod cache;
 mod status;
 mod weburl;
@@ -132,7 +133,7 @@ async fn main() -> Result<()> {
             prog_bar.set_prefix("[2/5]");
             prog_bar.set_message(formatter.format("fetching..."));
 
-            let request = client.get(to_fetch.as_str()).send().await?;
+            let request = asyncreq::make_req(client.get(to_fetch.as_str())).await?;
             if !request.status().is_success() {
                 return Err(anyhow::anyhow!("failed to fetch url"));
             }
@@ -279,7 +280,7 @@ async fn main() -> Result<()> {
                     dirty_url.to_string()
                 };
 
-                match client.get(&url).send().await {
+                match asyncreq::make_req(client.get(&url)).await {
                     Ok(resp) => {
                         if !resp.status().is_success() {
                             post_resolved_urls.push(format!(


### PR DESCRIPTION
# Description

- Make parallel processing of url limited to 5 at once
- Make HTTP requests limited to 20 at once

## Checklist

- [x] Tests passing
- [x] Linting passing
- [x] Changes works (for reviewer)
